### PR TITLE
Allow setting a custom value for LIEUTENANT_INSTANCE env variable

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -28,6 +28,7 @@ parameters:
         addr: vault.todo
         path: kv
     api:
+      lieutenant_instance: ${lieutenant:namespace}
       manifest_version: ${lieutenant:images:api:version}
       manifest_url: https://raw.githubusercontent.com/projectsyn/lieutenant-api/${lieutenant:api:manifest_version}/deploy
       common_labels:

--- a/component/api.jsonnet
+++ b/component/api.jsonnet
@@ -125,6 +125,11 @@ local objects = [
                       name: 'STEWARD_IMAGE',
                       value: steward_image,
                     }
+                  else if e.name == 'LIEUTENANT_INSTANCE' then
+                    {
+                      name: 'LIEUTENANT_INSTANCE',
+                      value: params.api.lieutenant_instance,
+                    }
                   else
                     e
                   for e in super.env + [

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -153,6 +153,14 @@ Whether to enable TLS for the ingress.
 This requires either to set the correct `cert-manager` annotations or to add the certificate manually to the secret `lieutenant-api-cert`.
 
 
+== `api.lieutenant_instance`
+
+[horizontal]
+type:: string
+default:: `${lieutenant:namespace}`
+
+Sets the env variable `LIEUTENANT_INSTANCE` to the value specified here. By default the value is set to the name of the namespace.
+
 == `api.users`
 
 [horizontal]


### PR DESCRIPTION
This allows us to override the lieutenant instance name. Without this
override option, the LIEUTENANT_INSTANCE env variable will always be set
to the namespace name

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [ ] Update the ./CHANGELOG.md.
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
