### PR TITLE
Fix namespace of cluster role binding subject

### DIFF
--- a/component/operator.jsonnet
+++ b/component/operator.jsonnet
@@ -26,6 +26,9 @@ local objects = [
     roleRef+: {
       name: prefix + super.name,
     },
+    subjects: std.map(function(s) s {
+      namespace: params.namespace,
+    }, super.subjects),
   },
   service_account,
   deployment {

--- a/tests/unit/operator_test.go
+++ b/tests/unit/operator_test.go
@@ -48,6 +48,7 @@ func Test_OperatorRBAC(t *testing.T) {
 
 	assert.Equal(t, "lieutenant-operator-manager-rolebinding", rolebinding.Name)
 	assert.Equal(t, namespace, rolebinding.Namespace)
+	assert.Equal(t, namespace, rolebinding.Subjects[0].Namespace)
 
 	sa := &corev1.ServiceAccount{}
 	data, err = ioutil.ReadFile(testPath + "/10_operator/serviceaccount.yaml")


### PR DESCRIPTION
This PR fixes the namespace in the `ClusterRoleBinding`s `.Subject[].Namespace` fields.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
