### PR TITLE
Give API users access to CR status

### DIFF
--- a/component/api.jsonnet
+++ b/component/api.jsonnet
@@ -57,7 +57,9 @@ local user_role = kube.Role('lieutenant-api-user') {
       ],
       resources: [
         'clusters',
+        'clusters/status',
         'tenants',
+        'tenants/status',
       ],
       verbs: [
         'create',

--- a/tests/golden/defaults/lieutenant/lieutenant/20_api/role-lieutenant-api-user.yaml
+++ b/tests/golden/defaults/lieutenant/lieutenant/20_api/role-lieutenant-api-user.yaml
@@ -11,7 +11,9 @@ rules:
       - syn.tools
     resources:
       - clusters
+      - clusters/status
       - tenants
+      - tenants/status
     verbs:
       - create
       - delete


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

The Lieutenant API user needs to be able to get and modify the status of the cluster resources. This was an oversight in the last version bump.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
