### PR TITLE
Make component support both kube-libsonnet `v1.14.6' and 'v1.19.0'

### DIFF
--- a/component/api.jsonnet
+++ b/component/api.jsonnet
@@ -8,7 +8,8 @@ local role = std.parseJson(kap.yaml_load('lieutenant/manifests/api/' + params.ap
 local service_account = std.parseJson(kap.yaml_load('lieutenant/manifests/api/' + params.api.manifest_version + '/service_account.yaml'));
 local role_binding = std.parseJson(kap.yaml_load('lieutenant/manifests/api/' + params.api.manifest_version + '/role_binding.yaml'));
 local deployment = std.parseJson(kap.yaml_load('lieutenant/manifests/api/' + params.api.manifest_version + '/deployment.yaml'));
-local service = std.parseJson(kap.yaml_load('lieutenant/manifests/api/' + params.api.manifest_version + '/service.yaml'));
+local raw_service = std.parseJson(kap.yaml_load('lieutenant/manifests/api/' + params.api.manifest_version + '/service.yaml'));
+local service = kube.Service(raw_service.metadata.name) {} + raw_service;
 
 local image = params.images.api.registry + '/' + params.images.api.repository + ':' + params.images.api.version;
 local steward_image = params.images.steward.registry + '/' + params.images.steward.repository + ':' + params.images.steward.version;
@@ -25,10 +26,8 @@ local ingress = kube.Ingress('lieutenant-api') {
           paths: [
             {
               path: '/',
-              backend: {
-                serviceName: service.metadata.name,
-                servicePort: 80,
-              },
+              pathType: 'Prefix',
+              backend: service.name_port,
             },
           ],
         },

--- a/tests/golden/defaults/lieutenant/lieutenant/20_api/ingress-lieutenant-api.yaml
+++ b/tests/golden/defaults/lieutenant/lieutenant/20_api/ingress-lieutenant-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations: {}
@@ -14,9 +14,12 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: lieutenant-api
-              servicePort: 80
+              service:
+                name: lieutenant-api
+                port:
+                  name: http
             path: /
+            pathType: Prefix
   tls:
     - hosts:
         - lieutenant.todo

--- a/tests/unit/api_test.go
+++ b/tests/unit/api_test.go
@@ -10,7 +10,7 @@ import (
 
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	netv1b1 "k8s.io/api/networking/v1beta1"
+	netv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/yaml"
 )
@@ -43,7 +43,7 @@ func Test_APIDeployment(t *testing.T) {
 }
 
 func Test_APIIngress(t *testing.T) {
-	ing := &netv1b1.Ingress{}
+	ing := &netv1.Ingress{}
 	data, err := ioutil.ReadFile(testPath + "/20_api/ingress-lieutenant-api.yaml")
 	require.NoError(t, err)
 	err = yaml.UnmarshalStrict(data, ing)
@@ -64,12 +64,11 @@ func Test_APIIngress(t *testing.T) {
 	require.NotEmpty(t, ing.Spec.Rules[0].HTTP.Paths)
 	p := ing.Spec.Rules[0].HTTP.Paths[0]
 	require.Equal(t, "/", p.Path)
-	require.Equal(t, svc.Name, p.Backend.ServiceName)
+	require.Equal(t, svc.Name, p.Backend.Service.Name)
 
-  require.NotEmpty(t, ing.Spec.TLS)
-  require.NotEmpty(t, ing.Spec.TLS[0].Hosts)
+	require.NotEmpty(t, ing.Spec.TLS)
+	require.NotEmpty(t, ing.Spec.TLS[0].Hosts)
 	assert.Equal(t, ing.Spec.Rules[0].Host, ing.Spec.TLS[0].Hosts[0])
-
 
 	deploy := &appv1.Deployment{}
 	data, err = ioutil.ReadFile(testPath + "/20_api/deployment-lieutenant-api.yaml")

--- a/tests/unit/defaults_test.go
+++ b/tests/unit/defaults_test.go
@@ -32,6 +32,7 @@ var (
 func skipValidation(path string) bool {
 	ignore := []string{
 		fmt.Sprintf("%s/00_crds", testPath),
+		fmt.Sprintf("%s/20_api/ingress-lieutenant-api.yaml", testPath),
 	}
 	for _, iv := range ignore {
 		if iv == path {

--- a/tests/unit/rbac_test.go
+++ b/tests/unit/rbac_test.go
@@ -30,12 +30,12 @@ func Test_RBAC(t *testing.T) {
 				Kind: rbacv1.UserKind,
 			},
 		},
-    "t-foo-1": {
+		"t-foo-1": {
 			{
 				Name: "u-bar-2",
 				Kind: rbacv1.UserKind,
 			},
-      {
+			{
 				Name: "g-buzz",
 				Kind: rbacv1.GroupKind,
 			},


### PR DESCRIPTION
With https://github.com/projectsyn/commodore/pull/418 we switched to kube-libsonnet `v1.19.0` which uses `networking.k8s.io/v1`. 

With this PR we produce valid Ingress definitions, no matter what commodore version we use.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
