### PR TITLE
Fix typo that rendered the Vault auth path unusable

### DIFF
--- a/component/operator.jsonnet
+++ b/component/operator.jsonnet
@@ -75,7 +75,7 @@ local objects = [
                       {
                         name: 'VAULT_AUTH_PATH',
                         value: params.operator.vault.auth_path,
-                      }
+                      },
                       {
                         name: 'VAULT_SECRET_ENGINE_PATH',
                         value: params.operator.vault.path,

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -2,7 +2,8 @@ parameters:
   lieutenant:
     operator:
       vault:
-        enabled: false
+        enabled: true
+        auth_path: foo
     api:
       default_githost: gitlab-com
     tenant_rbac:

--- a/tests/golden/defaults/lieutenant/lieutenant/10_operator/deployment.yaml
+++ b/tests/golden/defaults/lieutenant/lieutenant/10_operator/deployment.yaml
@@ -40,7 +40,13 @@ spec:
             - name: LIEUTENANT_DELETE_PROTECTION
               value: 'false'
             - name: SKIP_VAULT_SETUP
-              value: 'true'
+              value: 'false'
+            - name: VAULT_ADDR
+              value: vault.todo
+            - name: VAULT_AUTH_PATH
+              value: foo
+            - name: VAULT_SECRET_ENGINE_PATH
+              value: kv
           image: quay.io/projectsyn/lieutenant-operator:1.3.0
           livenessProbe:
             httpGet:

--- a/tests/unit/operator_test.go
+++ b/tests/unit/operator_test.go
@@ -27,7 +27,7 @@ func Test_OperatorDeployment(t *testing.T) {
 	assert.Len(t, deploy.Spec.Template.Spec.Containers, 1)
 	c := deploy.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, operatorImage, c.Image)
-	assert.Len(t, c.Env, 7)
+	assert.Len(t, c.Env, 10)
 }
 
 func Test_OperatorRBAC(t *testing.T) {


### PR DESCRIPTION


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
