### PR TITLE
Add option to configure environment variables for API

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -43,6 +43,7 @@ parameters:
       users:
         - kind: ServiceAccount
           name: lieutenant-api-user
+      env: {}
     tenant_rbac: {}
     githosts: {}
     auth_delegation: {}

--- a/component/api.jsonnet
+++ b/component/api.jsonnet
@@ -129,26 +129,14 @@ local objects = [
             if c.name == 'lieutenant-api' then
               c {
                 image: image,
-                env: mergeEnvVars([
-                  if e.name == 'STEWARD_IMAGE' then
-                    {
-                      name: 'STEWARD_IMAGE',
-                      value: steward_image,
-                    }
-                  else if e.name == 'LIEUTENANT_INSTANCE' then
-                    {
-                      name: 'LIEUTENANT_INSTANCE',
-                      value: params.api.lieutenant_instance,
-                    }
-                  else
-                    e
-                  for e in super.env + [
-                    {
-                      name: 'DEFAULT_API_SECRET_REF_NAME',
-                      value: params.api.default_githost,
-                    },
-                  ]
-                ], com.envList(params.api.env)),
+                env: mergeEnvVars(
+                  super.env,
+                  com.envList({
+                    STEWARD_IMAGE: steward_image,
+                    LIEUTENANT_INSTANCE: params.api.lieutenant_instance,
+                    DEFAULT_API_SECRET_REF_NAME: params.api.default_githost,
+                  } + params.api.env)
+                ),
               }
             else
               c

--- a/docs/modules/ROOT/pages/how-tos/vcluster.adoc
+++ b/docs/modules/ROOT/pages/how-tos/vcluster.adoc
@@ -123,3 +123,24 @@ parameters:
     syn:
       registration_url: https://api.syn.example.com/install/steward.json?token=XRaRSHafWa28afE72F2aCY==
 ----
+
+=== Commodore configuration auto discovery
+
+Commodore has the feature to discover the OIDC configuration from the Lieutenant API.
+That way Commodore user don't need to know the URL of the IDP or the OIDC client ID.
+
+To use this feature you need to pass this information to the Lieutenant API
+
+[code,yaml]
+----
+parameters:
+  lieutenant:
+    api:
+      ingress:
+        host: api-prod.syn.example.com
+        env:
+          OIDC_CLIENT_ID: lieutenant <1>
+          OIDC_DISCOVERY_URL=https://id.example.com/auth/realms/main/.well-known/openid-configuration <2>
+----
+<1> The same client ID used for vcluster
+<2> The OIDC discovery endpoint of the IDP

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -120,6 +120,27 @@ default:: ``
 The githost to be used by default for new tenants.
 
 
+== `api.env`
+
+[horizontal]
+type:: list
+default:: `{}`
+example::
++
+[source,yaml]
+----
+env:
+  OIDC_DISCOVERY_URL:
+    secretKeyRef:
+      name: oidc-config
+      key: discovery
+  OIDC_CLIENT_ID: lieutenant
+----
+
+Additional environment that should be passed to the Lieutenant API.
+If a dict is given `valueFrom:` is assumed.
+
+
 == `api.ingress.host`
 
 [horizontal]

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -6,6 +6,9 @@ parameters:
         auth_path: foo
     api:
       default_githost: gitlab-com
+      env:
+        OIDC_DISCOVERY_URL: 'https://idp.test.com/'
+        OIDC_CLIENT_ID: lieutenant
     tenant_rbac:
       t-foo-124:
         - name: "u-bar-1"

--- a/tests/golden/defaults/lieutenant/lieutenant/20_api/deployment-lieutenant-api.yaml
+++ b/tests/golden/defaults/lieutenant/lieutenant/20_api/deployment-lieutenant-api.yaml
@@ -22,16 +22,20 @@ spec:
         - command:
             - lieutenant-api
           env:
+            - name: DEFAULT_API_SECRET_REF_NAME
+              value: gitlab-com
+            - name: LIEUTENANT_INSTANCE
+              value: lieutenant
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: LIEUTENANT_INSTANCE
+            - name: OIDC_CLIENT_ID
               value: lieutenant
+            - name: OIDC_DISCOVERY_URL
+              value: https://idp.test.com/
             - name: STEWARD_IMAGE
               value: docker.io/projectsyn/steward:v0.6.0
-            - name: DEFAULT_API_SECRET_REF_NAME
-              value: gitlab-com
           image: docker.io/projectsyn/lieutenant-api:v0.9.0
           imagePullPolicy: Always
           livenessProbe:

--- a/tests/unit/api_test.go
+++ b/tests/unit/api_test.go
@@ -29,7 +29,7 @@ func Test_APIDeployment(t *testing.T) {
 	assert.Len(t, deploy.Spec.Template.Spec.Containers, 1)
 	c := deploy.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, apiImage, c.Image)
-	assert.Len(t, c.Env, 4)
+	assert.Len(t, c.Env, 6)
 
 	for _, env := range c.Env {
 		switch env.Name {


### PR DESCRIPTION
This enables us to configure the OIDC config


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
