### PR TITLE
Fix creation of ServiceAccount token secrets for additional API users on K8s 1.24+

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -43,6 +43,7 @@ parameters:
         host: lieutenant.todo
         annotations: {}
         tls: true
+      create_user_serviceaccount_secrets: true
       users:
         - kind: ServiceAccount
           name: lieutenant-api-user

--- a/component/api.jsonnet
+++ b/component/api.jsonnet
@@ -108,7 +108,7 @@ local user_sa_secrets =
             'kubernetes.io/service-account.name': u.name,
           },
         },
-        type: 'kubernets.io/service-account-token',
+        type: 'kubernetes.io/service-account-token',
       }
       for u in params.api.users
       if u.kind == 'ServiceAccount'

--- a/component/api.jsonnet
+++ b/component/api.jsonnet
@@ -98,6 +98,25 @@ local user_service_accounts = [
   if u.kind == 'ServiceAccount'
 ];
 
+local user_sa_secrets =
+  if params.api.create_user_serviceaccount_secrets then
+    [
+      kube.Secret(u.name) {
+        metadata: {
+          name: u.name,
+          annotations: {
+            'kubernetes.io/service-account.name': u.name,
+          },
+        },
+        type: 'kubernets.io/service-account-token',
+      }
+      for u in params.api.users
+      if u.kind == 'ServiceAccount'
+    ]
+  else
+    [];
+
+
 local objects = [
   role,
   service_account,
@@ -141,7 +160,7 @@ local objects = [
     },
   },
   ingress,
-] + user_service_accounts;
+] + user_service_accounts + user_sa_secrets;
 
 
 {

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -207,6 +207,16 @@ default:: `${lieutenant:namespace}`
 
 Sets the env variable `LIEUTENANT_INSTANCE` to the value specified here. By default the value is set to the name of the namespace.
 
+== `api.create_user_serviceaccount_secrets`
+
+[horizontal]
+type:: bool
+default:: `true`
+
+This parameter controls whether the component creates a ServiceAccount token secret for each user with `kind: ServiceAccount` listed in parameter `api.users`.
+
+This parameter should always be set to `true` on Kubernetes 1.24+, because Kubernetes 1.24 and newer don't automatically create a ServiceAccount token secret anymore.
+
 == `api.users`
 
 [horizontal]

--- a/tests/golden/defaults/lieutenant/lieutenant/20_api/secret-lieutenant-api-user.yaml
+++ b/tests/golden/defaults/lieutenant/lieutenant/20_api/secret-lieutenant-api-user.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: lieutenant-api-user
+  labels:
+    app.kubernetes.io/name: lieutenant-api
+    app.kubernetes.io/part-of: project-syn
+  name: lieutenant-api-user
+  namespace: lieutenant
+type: kubernets.io/service-account-token

--- a/tests/golden/defaults/lieutenant/lieutenant/20_api/secret-lieutenant-api-user.yaml
+++ b/tests/golden/defaults/lieutenant/lieutenant/20_api/secret-lieutenant-api-user.yaml
@@ -9,4 +9,4 @@ metadata:
     app.kubernetes.io/part-of: project-syn
   name: lieutenant-api-user
   namespace: lieutenant
-type: kubernets.io/service-account-token
+type: kubernetes.io/service-account-token


### PR DESCRIPTION
We need to manually manage ServiceAccount token secrets for additional API users configured through the component. This commit adds a new parameter `api.create_user_serviceaccount_secrets` which controls whether the component creates ServiceAccount token secrets as documented in the [upstream Kubernetes docs].

The component defaults the new parameter to `true` to ensure that the component default configuration works correctly on K8s 1.24+.

[upstream Kubernetes docs]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-service-account-api-token


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
