### PR TITLE
Ensure we don't add empty `data: {}` in user token secrets

### DIFF
--- a/component/api.jsonnet
+++ b/component/api.jsonnet
@@ -109,6 +109,8 @@ local user_sa_secrets =
           },
         },
         type: 'kubernetes.io/service-account-token',
+        // hide data, so ArgoCD doesn't try to keep it empty
+        data:: {},
       }
       for u in params.api.users
       if u.kind == 'ServiceAccount'

--- a/tests/golden/defaults/lieutenant/lieutenant/20_api/secret-lieutenant-api-user.yaml
+++ b/tests/golden/defaults/lieutenant/lieutenant/20_api/secret-lieutenant-api-user.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
-data: {}
 kind: Secret
 metadata:
   annotations:


### PR DESCRIPTION
Without this, ArgoCD will want to ensure that all the user token secrets keep an empty `data: {}` field. By completely omitting `data`, ArgoCD doesn't care if Kubernetes fills in some data.


Follow-up to #54 

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
