### PR TITLE
Ensure RoleBinding names created from `tenant_rbac` are unique

### DIFF
--- a/component/rbac.jsonnet
+++ b/component/rbac.jsonnet
@@ -5,9 +5,8 @@ local inv = kap.inventory();
 local params = inv.parameters.lieutenant;
 
 {
-  [std.asciiLower(ten)]: kube.RoleBinding(ten) {
-    metadata: {
-      name: ten,
+  [std.asciiLower(ten)]: kube.RoleBinding('custom-%s' % [ ten ]) {
+    metadata+: {
       namespace: params.namespace,
     },
     roleRef: {

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -241,9 +241,12 @@ For entries with type `ServiceAccount` the component will create the correspondi
 type:: dict
 default:: {}
 
-Role based access control to the created tenant resources.
-Lieutenant creates a `Role` for each tenant.
+Role based access control to the created tenant (or cluster) resources.
+Lieutenant creates a `Role` for each tenant and cluster using the tenant or cluster ID as the role name.
 
+The component will create a RoleBinding named `custom-<key>` for each entry in the parameter.
+The `roleRef` for each RoleBinding will use the key in the parameter as the role name.
+We prefix the RoleBinding name with `custom-`, because Lieutenant already manages RoleBindings which use the tenant and cluster IDs as names.
 
 [source,yaml]
 ----
@@ -258,10 +261,16 @@ tenant_rbac:
       kind: 'Group'
     - name: 'u-bar-1'
       kind: 'User'
+  c-bar-546:
+    - name: 'u-bar-1'
+      kind: 'User'
 ----
 
-The example configuration above will grant user `u-bar-1` and service account `sa-bar` read access to all Clusters owned by Tenant `t-foo-324`.
-And it will grant group `g-buzz` and user `u-bar-1` read access to all Clusters owned by Tenant `t-foo-1`.
+The example configuration above will create
+
+* a RoleBinding `custom-t-foo-324` which grants user `u-bar-1` and service account `sa-bar` read access to all clusters owned by tenant `t-foo-324`.
+* a RoleBinding `custom-t-foo-1` which grants group `g-buzz` and user `u-bar-1` read access to all clusters owned by tenant `t-foo-1`.
+* a RoleBinding `custom-c-bar-546` which grants user `u-bar-1` read access to cluster `c-bar-546`.
 
 This can usually only be configured after the initial setup of Lieutenant.
 

--- a/tests/golden/defaults/lieutenant/lieutenant/40_rbac/t-foo-1.yaml
+++ b/tests/golden/defaults/lieutenant/lieutenant/40_rbac/t-foo-1.yaml
@@ -1,7 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: t-foo-1
+  annotations: {}
+  labels:
+    name: custom-t-foo-1
+  name: custom-t-foo-1
   namespace: lieutenant
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/defaults/lieutenant/lieutenant/40_rbac/t-foo-124.yaml
+++ b/tests/golden/defaults/lieutenant/lieutenant/40_rbac/t-foo-124.yaml
@@ -1,7 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: t-foo-124
+  annotations: {}
+  labels:
+    name: custom-t-foo-124
+  name: custom-t-foo-124
   namespace: lieutenant
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/defaults/lieutenant/lieutenant/40_rbac/t-foo-324.yaml
+++ b/tests/golden/defaults/lieutenant/lieutenant/40_rbac/t-foo-324.yaml
@@ -1,7 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: t-foo-324
+  annotations: {}
+  labels:
+    name: custom-t-foo-324
+  name: custom-t-foo-324
   namespace: lieutenant
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/unit/rbac_test.go
+++ b/tests/unit/rbac_test.go
@@ -49,7 +49,9 @@ func Test_RBAC(t *testing.T) {
 		err = yaml.UnmarshalStrict(data, rb)
 		require.NoError(t, err)
 
-		assert.Equal(t, ten, rb.Name)
+		rbName := fmt.Sprintf("custom-%s", ten)
+
+		assert.Equal(t, rbName, rb.Name)
 		assert.Equal(t, namespace, rb.Namespace)
 		assert.ElementsMatch(t, sub, rb.Subjects)
 	}


### PR DESCRIPTION
The previous approach use the target role's name for the RoleBidning name. This leads to conflicts with Lieutenant-managed RoleBindings which are created for each cluster and tenant.

This commit adds prefix `custom-` to the RoleBinding names created from `tenant_rbac` to ensure they don't conflict with Lieutenant-managed RoleBindings.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
